### PR TITLE
fix(method): Allow objects to be passed to subselections

### DIFF
--- a/core/methods/databases/expand-references.js
+++ b/core/methods/databases/expand-references.js
@@ -51,7 +51,7 @@ module.exports = {
               const script = ScriptsManager.get(`Storage${storage}Read`);
               data[field] = await script.run({
                 model: refmodel,
-                id: data[field],
+                id,
                 selections: subselections
               });
             } catch (err) {


### PR DESCRIPTION
Pass id to the read script, so we can use objects instead of primitive types here.